### PR TITLE
Fix the prevention of repeated decimals

### DIFF
--- a/calculator.js
+++ b/calculator.js
@@ -3,6 +3,11 @@ var period = false;
 
 // Change Display
 function d(val) {
+	// Clearing the display
+	if( val == "" ) {
+		// Reset your period toggle
+		period = false;
+	}
 	document.getElementById("d").value = val;
 }
 


### PR DESCRIPTION
When clearing the display, it should reset the period toggle, otherwise the user can't enter a decimal if they do the following:
1. Enter a decimal
2. Clear the display
3. Can't enter decimal :(